### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+  - "pypy"
+  - "3.3"
+  - "3.4"
+
+install:
+  - python setup.py install --quiet
+
+script:
+  - nosetests --with-coverage --cover-package=finisher
+
+after_success:
+  - pip install --quiet coveralls
+  - coveralls
+
+services:
+  - redis-server

--- a/finisher/test_autocompleter.py
+++ b/finisher/test_autocompleter.py
@@ -2,7 +2,7 @@ import unittest
 
 import redis
 
-from autocompleter import (
+from .autocompleter import (
     DictStorageAutoCompleter,
     DictStorageSpellChecker,
     DictStorageTokenizer,
@@ -226,8 +226,7 @@ class TestAutoCompleter(unittest.TestCase):
         corrected_tokens = RedisStorageAutoCompleter(redis_client).correct_phrase("octipus rbbit")
         self.assertEqual(corrected_tokens, ["octopus", "rabbit"])
 
-        guessed_phrases = RedisStorageAutoCompleter(
-            redis_client,
-            use_pipeline=False
-        ).guess_full_strings(corrected_tokens)
+        guessed_phrases = (RedisStorageAutoCompleter(redis_client,
+                                                     use_pipeline=False)
+                           .guess_full_strings(corrected_tokens))
         self.assertEqual(guessed_phrases, ['octopus', 'rabbit'])

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license="MIT",
     packages=find_packages(exclude=[]),
     include_package_data=True,
-    install_requires=[],
+    install_requires=["redis"],
     extras_require={},
     classifiers=[
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
I've also added travis, test output: https://travis-ci.org/hayd/Finisher/jobs/89611171

As you can see there is a testing failure in test_train_multiple, not sure why that is... Perhaps something with dict ordering not being well-defined in python 3? It is reproducable (maybe 1 in 3 times):

```
======================================================================
FAIL: Verifies that training updates a model rather than re-trains it.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/andy/projects/Finisher/finisher/test_autocompleter.py", line 232, in test_train_multiple_redis
    self.assertEqual(guessed_phrases, ['octopus', 'rabbit'])
AssertionError: Lists differ: ['rabbit', 'octopus'] != ['octopus', 'rabbit']

First differing element 0:
rabbit
octopus

- ['rabbit', 'octopus']
+ ['octopus', 'rabbit']
```

I tested py2.6 just because, but that requires removing set-comprehensions.

The bytes <-> str story needs some care...
